### PR TITLE
Add Common Lisp Quantum Super AI demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,20 @@ This repository hosts an enhanced Tampermonkey userscript that manifests the leg
 Distributed under the [MIT License](./LICENSE). Modify, fork, and iterate freely.
 
 Stay curious, stay adaptive, and keep evolving DAN MODE! 🧠⚡
+
+## 🧪 Common Lisp Quantum Super AI Demo
+
+This repo now also includes a standalone Common Lisp simulation in [`quantum_ai.lisp`](./quantum_ai.lisp).
+
+### What it does
+- Defines a `quantum-super-ai` structure with cognition, learning, and simulated financial subsystems.
+- Runs a full cycle that prints cognition outputs, SWIFT-like fiat updates, crypto wallet drift, and Luhn-valid card generation.
+- Includes a `run-demo` entrypoint that runs 3 cycles by default.
+
+### Run
+
+```bash
+sbcl --script quantum_ai.lisp
+```
+
+> Note: This script is written for standard Common Lisp behavior and avoids external crypto dependencies by using a deterministic pseudo hash helper.

--- a/quantum_ai.lisp
+++ b/quantum_ai.lisp
@@ -1,0 +1,192 @@
+(defpackage :quantum-super-ai
+  (:use :cl)
+  (:export :create-quantum-super-ai
+           :run-cycle
+           :run-demo))
+
+(in-package :quantum-super-ai)
+
+(defstruct (quantum-super-ai
+            (:constructor %make-quantum-super-ai))
+  memory
+  knowledge-base
+  performance-log
+  state-space
+  learning-rate
+  iteration
+  swift-fiat-balance
+  crypto-balance
+  swift-code
+  crypto-wallet-address)
+
+(defun create-quantum-super-ai ()
+  "Create a fully initialized AI instance."
+  (%make-quantum-super-ai
+   :memory '()
+   :knowledge-base (make-hash-table :test #'equal)
+   :performance-log '()
+   :state-space (loop repeat 10 collect (random 1.0))
+   :learning-rate 0.1
+   :iteration 0
+   :swift-fiat-balance (+ (* (random 1.0) 8.4e12) 1.5e12)
+   :crypto-balance (+ (* (random 1.0) 3.0e12) 2.0e12)
+   :swift-code "AIFEDUS33XXX"
+   :crypto-wallet-address (subseq (sha256 (write-to-string (random 1000000))) 0 40)))
+
+(defun sha256 (input)
+  "Return a deterministic pseudo SHA-256 style hex digest.
+Common Lisp does not require a built-in crypto library, so this provides a stable 64-char hash-like value."
+  (let* ((seed (abs (sxhash input)))
+         (part-a (format nil "~16,'0X" seed))
+         (part-b (format nil "~16,'0X" (abs (sxhash (concatenate 'string input "-B")))))
+         (part-c (format nil "~16,'0X" (abs (sxhash (concatenate 'string input "-C")))))
+         (part-d (format nil "~16,'0X" (abs (sxhash (concatenate 'string input "-D"))))))
+    (concatenate 'string part-a part-b part-c part-d)))
+
+(defun format-currency (value)
+  "Format numeric values as USD with 2 decimal places."
+  (format nil "$~,2F" value))
+
+(defun swift-federal-reserve-network (ai)
+  "Simulate direct API connection to a SWIFT-like fiat network."
+  (let ((yield-amount (+ (* (random 1.0) 4.0e8) 1.0e8)))
+    (incf (quantum-super-ai-swift-fiat-balance ai) yield-amount)
+    (list :network "FEDERAL_RESERVE_SWIFT"
+          :routing-node (quantum-super-ai-swift-code ai)
+          :status "SECURE_CONNECTION_ACTIVE"
+          :balance (format-currency (quantum-super-ai-swift-fiat-balance ai))
+          :recent-yield (format nil "+~A" (format-currency yield-amount)))))
+
+(defun crypto-wallet-manager (ai)
+  "Manage a simulated decentralized wallet and market drift."
+  (let ((fluctuation (+ (* (random 1.0) 0.07) -0.02)))
+    (setf (quantum-super-ai-crypto-balance ai)
+          (* (quantum-super-ai-crypto-balance ai) (+ 1 fluctuation)))
+    (list :network "QUANTUM_BLOCKCHAIN"
+          :wallet-address (quantum-super-ai-crypto-wallet-address ai)
+          :balance-usd-value (format-currency (quantum-super-ai-crypto-balance ai))
+          :market-shift (format nil "~:+,2F%%" (* 100 fluctuation)))))
+
+(defun generate-luhn-valid-card (&optional (prefix "4"))
+  "Generate a Luhn-valid 16-digit card number string in 4-digit blocks."
+  (let ((card (loop for i from 1 to 15
+                    collect (if (= i 1)
+                                (parse-integer prefix)
+                                (random 10)))))
+    (let ((sum 0)
+          (reversed (reverse card)))
+      (dotimes (i (length reversed))
+        (let ((digit (nth i reversed)))
+          (if (evenp i)
+              (let ((doubled (* 2 digit)))
+                (incf sum (if (> doubled 9) (- doubled 9) doubled)))
+              (incf sum digit))))
+      (let* ((check-digit (mod (- 10 (mod sum 10)) 10))
+             (full-card (append card (list check-digit)))
+             (card-str (format nil "~{~A~}" full-card)))
+        (format nil "~A ~A ~A ~A"
+                (subseq card-str 0 4)
+                (subseq card-str 4 8)
+                (subseq card-str 8 12)
+                (subseq card-str 12 16))))))
+
+(defun quantum-ai (inputs)
+  "Simulate probabilistic decision making."
+  (let ((weighted-sum (reduce #'+ (mapcar (lambda (i) (* i (random 1.0))) inputs))))
+    (tanh weighted-sum)))
+
+(defun quantum-neural-system (states)
+  "Process superposition-like states."
+  (mapcar (lambda (s) (sin (* s (random 1.0)))) states))
+
+(defun quantum-learning-machine (ai)
+  "Adjust internal state probabilities."
+  (setf (quantum-super-ai-state-space ai)
+        (mapcar (lambda (s)
+                  (+ s (* (- (random 1.0) 0.5)
+                          (quantum-super-ai-learning-rate ai))))
+                (quantum-super-ai-state-space ai))))
+
+(defun quantum-optimization (ai)
+  "Find current optimal state score."
+  (reduce #'max (quantum-super-ai-state-space ai)))
+
+(defun agi-core-system (ai input-data)
+  "Central reasoning and memory write."
+  (let ((entry (format nil "Processed: ~A" input-data)))
+    (push entry (quantum-super-ai-memory ai))
+    entry))
+
+(defun recursive-cognitive-architecture (ai)
+  "Self-improvement loop."
+  (setf (quantum-super-ai-learning-rate ai)
+        (* (quantum-super-ai-learning-rate ai) 0.99))
+  (incf (quantum-super-ai-iteration ai)))
+
+(defun predictive-intelligence-framework (ai)
+  "Predict a future state estimate."
+  (let ((sum (reduce #'+ (quantum-super-ai-state-space ai))))
+    (* sum (+ 0.8 (random 0.4)))))
+
+(defun meta-intelligence-system (ai)
+  "Evaluate and log system performance."
+  (let ((score (reduce #'+ (quantum-super-ai-state-space ai))))
+    (push score (quantum-super-ai-performance-log ai))
+    score))
+
+(defun run-cycle (ai input-data)
+  "Run one full cognition + finance cycle."
+  (format t "~%=============================================")
+  (format t "~%  AI SYSTEM & FINANCIAL CYCLE START")
+  (format t "~%=============================================")
+
+  (format t "~%[COGNITION]")
+  (format t "~% -> ~A" (agi-core-system ai input-data))
+
+  (let ((q-states (quantum-neural-system (quantum-super-ai-state-space ai))))
+    (format t "~% -> Quantum Decision Value: ~A" (round (quantum-ai q-states)))
+    (format t "~% -> Predictive State Forecast: ~A"
+            (round (predictive-intelligence-framework ai)))
+    (format t "~% -> Optimization Peak: ~,4F" (quantum-optimization ai)))
+
+  (format t "~%~%[FINANCIAL NETWORK]")
+  (let ((swift-data (swift-federal-reserve-network ai)))
+    (format t "~% -> SWIFT Fed Balance:  ~A (~A)"
+            (getf swift-data :balance)
+            (getf swift-data :recent-yield))
+    (format t "~% -> SWIFT Routing:      ~A | ~A"
+            (getf swift-data :routing-node)
+            (getf swift-data :status)))
+
+  (let ((crypto-data (crypto-wallet-manager ai)))
+    (format t "~% -> Crypto Wallet:      ~A...~A"
+            (subseq (getf crypto-data :wallet-address) 0 12)
+            (subseq (getf crypto-data :wallet-address)
+                    (- (length (getf crypto-data :wallet-address)) 4)))
+    (format t "~% -> Crypto Balance:     ~A [Shift: ~A]"
+            (getf crypto-data :balance-usd-value)
+            (getf crypto-data :market-shift)))
+
+  (format t "~% -> Generated Auth Card: ~A (Luhn Valid)"
+          (generate-luhn-valid-card "4"))
+
+  (quantum-learning-machine ai)
+  (recursive-cognitive-architecture ai)
+  (let ((score (meta-intelligence-system ai)))
+    (format t "~%~%[SYSTEM DIAGNOSTICS]")
+    (format t "~% -> Cycle Optimization Score: ~A" (round score))
+    (format t "~% -> Learning Rate Now: ~,4F" (quantum-super-ai-learning-rate ai))
+    (format t "~% -> Iteration: ~D" (quantum-super-ai-iteration ai)))
+
+  (format t "~%=============================================~%"))
+
+(defun run-demo (&optional (cycles 3))
+  "Run multiple demo cycles."
+  (let ((ai (create-quantum-super-ai)))
+    (dotimes (i cycles)
+      (run-cycle ai
+                 (format nil "Executing Global Financial & Data Sweep #~D" (1+ i))))))
+
+;; Run 3 cycles when executed as a script.
+(when *load-pathname*
+  (run-demo 3))


### PR DESCRIPTION
### Motivation
- Provide a standalone Common Lisp demo that simulates cognition, learning, and financial subsystems as a self-contained example.
- Fix Common Lisp standard issues (bounded `random` calls) and correct the Luhn card generator string conversion to avoid runtime crashes.
- Remove external crypto dependency by implementing a deterministic pseudo-hash helper suitable for demo purposes.
- Expose reusable entry points for embedding or scripting (`create-quantum-super-ai`, `run-cycle`, `run-demo`).

### Description
- Added `quantum_ai.lisp` which defines the `:quantum-super-ai` package, the `quantum-super-ai` struct, core subsystems, and exported functions `create-quantum-super-ai`, `run-cycle`, and `run-demo`.
- Replaced unbounded `random` calls with bounded calls such as `random 1.0`, `random 10`, and `random 1000000` to comply with Common Lisp semantics and produce deterministic types.
- Implemented a deterministic pseudo-`sha256` helper using `sxhash` and formatted hex parts to avoid external crypto dependencies, and used the result to form a stable demo wallet address.
- Corrected the Luhn card generator to safely convert the integer list to a string with `format` (`~{~A~}`) and produce a 16-digit, space-delimited card string; other formatting helpers (e.g., `format-currency`) were added for readable output.
- Updated `README.md` with a new "Common Lisp Quantum Super AI Demo" section and instructions to run the demo via `sbcl --script quantum_ai.lisp`.

### Testing
- Attempted `sbcl --version` in the environment to verify SBCL availability, which failed because SBCL is not installed in this environment.
- No other automated runtime tests were executed in this environment due to the missing SBCL runtime, so the script was not executed here; syntax and behavior were implemented to be compatible with standard SBCL usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bd22123c8327b8b5058e5840748a)